### PR TITLE
WIP - support generation of xcframework [go1.15]

### DIFF
--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -184,7 +184,7 @@ func goIOSBind(gobind string, pkgs []*packages.Package, archs []string) error {
 		}
 	}
 	// Combine frameworks into xcframework
-	cmd = exec.Command("xcodebuild", "-create-xcframework", "-framework", tmpdir+"/arm64/Sample.framework", "-framework", tmpdir+"/amd64/Sample.framework", "-framework", tmpdir+"/catalyst/Sample.framework", "-output", buildO)
+	cmd = exec.Command("xcodebuild", "-create-xcframework", "-framework", tmpdir+"/arm64/" + title + ".framework", "-framework", tmpdir+"/amd64/" + title + ".framework", "-framework", tmpdir+"/catalyst/" + title + ".framework", "-output", buildO)
 	err := runCmd(cmd)
 	return err
 }

--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -177,14 +177,14 @@ func goIOSBind(gobind string, pkgs []*packages.Package, archs []string) error {
 		}
 		// Thin the arm64 framework with lipo
 		if arch == "arm64" {
-			cmd = exec.Command("xcrun", "lipo", buildTemp + "/Versions/A/" + title, "-thin", "arm64", "-output", buildTemp + "/Versions/A/" + title)
+			cmd = exec.Command("xcrun", "lipo", buildTemp+"/Versions/A/"+title, "-thin", "arm64", "-output", buildTemp+"/Versions/A/"+title)
 			if err := runCmd(cmd); err != nil {
 				return err
 			}
 		}
 	}
 	// Combine frameworks into xcframework
-	cmd = exec.Command("xcodebuild", "-create-xcframework", "-framework", tmpdir+"/arm64/" + title + ".framework", "-framework", tmpdir+"/amd64/" + title + ".framework", "-framework", tmpdir+"/catalyst/" + title + ".framework", "-output", buildO)
+	cmd = exec.Command("xcodebuild", "-create-xcframework", "-framework", tmpdir+"/arm64/"+title+".framework", "-framework", tmpdir+"/amd64/"+title+".framework", "-framework", tmpdir+"/catalyst/"+title+".framework", "-output", buildO)
 	err := runCmd(cmd)
 	return err
 }

--- a/cmd/gomobile/bind_test.go
+++ b/cmd/gomobile/bind_test.go
@@ -112,7 +112,7 @@ func TestBindIOS(t *testing.T) {
 	}()
 	buildN = true
 	buildX = true
-	buildO = "Asset.framework"
+	buildO = "Asset.xcframework"
 	buildTarget = "ios/arm64"
 
 	tests := []struct {
@@ -126,7 +126,7 @@ func TestBindIOS(t *testing.T) {
 			prefix: "Foo",
 		},
 		{
-			out: "Abcde.framework",
+			out: "Abcde.xcframework",
 		},
 	}
 	for _, tc := range tests {
@@ -160,7 +160,7 @@ func TestBindIOS(t *testing.T) {
 			BitcodeEnabled bool
 		}{
 			outputData:     output,
-			Output:         buildO[:len(buildO)-len(".framework")],
+			Output:         buildO[:len(buildO)-len(".xcframework")],
 			Prefix:         tc.prefix,
 			BitcodeEnabled: bitcodeEnabled,
 		}
@@ -194,26 +194,28 @@ jar c -C $WORK/javac-output .
 var bindIOSTmpl = template.Must(template.New("output").Parse(`GOMOBILE={{.GOPATH}}/pkg/gomobile
 WORK=$WORK
 GOOS=darwin CGO_ENABLED=1 gobind -lang=go,objc -outdir=$WORK -tags=ios{{if .Prefix}} -prefix={{.Prefix}}{{end}} golang.org/x/mobile/asset
+rm -r -f "{{.Output}}.xcframework"
 mkdir -p $WORK/src
-PWD=$WORK/src GOOS=darwin GOARCH=arm64 CC=iphoneos-clang CXX=iphoneos-clang++ CGO_CFLAGS=-isysroot=iphoneos -miphoneos-version-min=7.0 {{if .BitcodeEnabled}}-fembed-bitcode {{end}}-arch arm64 CGO_CXXFLAGS=-isysroot=iphoneos -miphoneos-version-min=7.0 {{if .BitcodeEnabled}}-fembed-bitcode {{end}}-arch arm64 CGO_LDFLAGS=-isysroot=iphoneos -miphoneos-version-min=7.0 {{if .BitcodeEnabled}}-fembed-bitcode {{end}}-arch arm64 CGO_ENABLED=1 GOPATH=$WORK:$GOPATH go build -tags ios -x -buildmode=c-archive -o $WORK/{{.Output}}-arm64.a ./gobind
-rm -r -f "{{.Output}}.framework"
-mkdir -p {{.Output}}.framework/Versions/A/Headers
-ln -s A {{.Output}}.framework/Versions/Current
-ln -s Versions/Current/Headers {{.Output}}.framework/Headers
-ln -s Versions/Current/{{.Output}} {{.Output}}.framework/{{.Output}}
-xcrun lipo -create -arch arm64 $WORK/{{.Output}}-arm64.a -o {{.Output}}.framework/Versions/A/{{.Output}}
-cp $WORK/src/gobind/{{.Prefix}}Asset.objc.h {{.Output}}.framework/Versions/A/Headers/{{.Prefix}}Asset.objc.h
-mkdir -p {{.Output}}.framework/Versions/A/Headers
-cp $WORK/src/gobind/Universe.objc.h {{.Output}}.framework/Versions/A/Headers/Universe.objc.h
-mkdir -p {{.Output}}.framework/Versions/A/Headers
-cp $WORK/src/gobind/ref.h {{.Output}}.framework/Versions/A/Headers/ref.h
-mkdir -p {{.Output}}.framework/Versions/A/Headers
-mkdir -p {{.Output}}.framework/Versions/A/Headers
-mkdir -p {{.Output}}.framework/Versions/A/Resources
-ln -s Versions/Current/Resources {{.Output}}.framework/Resources
-mkdir -p {{.Output}}.framework/Resources
-mkdir -p {{.Output}}.framework/Versions/A/Modules
-ln -s Versions/Current/Modules {{.Output}}.framework/Modules
+PWD=$WORK/src GOOS=darwin GOARCH=arm64 CC=iphoneos-clang CXX=iphoneos-clang++ CGO_CFLAGS=-isysroot=iphoneos -miphoneos-version-min=7.0 {{if .BitcodeEnabled}}-fembed-bitcode {{end}}-arch arm64 CGO_CXXFLAGS=-isysroot=iphoneos -miphoneos-version-min=7.0 {{if .BitcodeEnabled}}-fembed-bitcode {{end}}-arch arm64 CGO_LDFLAGS=-isysroot=iphoneos -miphoneos-version-min=7.0 {{if .BitcodeEnabled}}-fembed-bitcode {{end}}-arch arm64 CGO_ENABLED=1 ARCH=arm64 GOPATH=$WORK:$GOPATH go build -tags ios -x -buildmode=c-archive -o $WORK/{{.Output}}-arm64.a ./gobind
+mkdir -p $WORK/arm64/{{.Output}}.framework/Versions/A/Headers
+ln -s A $WORK/arm64/{{.Output}}.framework/Versions/Current
+ln -s Versions/Current/Headers $WORK/arm64/{{.Output}}.framework/Headers
+ln -s Versions/Current/{{.Output}} $WORK/arm64/{{.Output}}.framework/{{.Output}}
+xcrun lipo -create -arch arm64 $WORK/{{.Output}}-arm64.a -o $WORK/arm64/{{.Output}}.framework/Versions/A/{{.Output}}
+cp $WORK/src/gobind/{{.Prefix}}Asset.objc.h $WORK/arm64/{{.Output}}.framework/Versions/A/Headers/{{.Prefix}}Asset.objc.h
+mkdir -p $WORK/arm64/{{.Output}}.framework/Versions/A/Headers
+cp $WORK/src/gobind/Universe.objc.h $WORK/arm64/{{.Output}}.framework/Versions/A/Headers/Universe.objc.h
+mkdir -p $WORK/arm64/{{.Output}}.framework/Versions/A/Headers
+cp $WORK/src/gobind/ref.h $WORK/arm64/{{.Output}}.framework/Versions/A/Headers/ref.h
+mkdir -p $WORK/arm64/{{.Output}}.framework/Versions/A/Headers
+mkdir -p $WORK/arm64/{{.Output}}.framework/Versions/A/Headers
+mkdir -p $WORK/arm64/{{.Output}}.framework/Versions/A/Resources
+ln -s Versions/Current/Resources $WORK/arm64/{{.Output}}.framework/Resources
+mkdir -p $WORK/arm64/{{.Output}}.framework/Resources
+mkdir -p $WORK/arm64/{{.Output}}.framework/Versions/A/Modules
+ln -s Versions/Current/Modules $WORK/arm64/{{.Output}}.framework/Modules
+xcrun lipo $WORK/arm64/{{.Output}}.framework/Versions/A/{{.Output}} -thin arm64 -output $WORK/arm64/{{.Output}}.framework/Versions/A/{{.Output}}
+xcodebuild -create-xcframework -framework $WORK/arm64/{{.Output}}.framework -framework $WORK/amd64/{{.Output}}.framework -framework $WORK/catalyst/{{.Output}}.framework -output {{.Output}}.xcframework
 `))
 
 func TestBindIOSAll(t *testing.T) {
@@ -230,7 +232,7 @@ func TestBindIOSAll(t *testing.T) {
 	}()
 	buildN = true
 	buildX = true
-	buildO = "Asset.framework"
+	buildO = "Asset.xcframework"
 	buildTarget = "ios"
 
 	buf := new(bytes.Buffer)
@@ -290,7 +292,7 @@ func TestBindWithGoModules(t *testing.T) {
 			case "android":
 				out = filepath.Join(dir, "cgopkg.aar")
 			case "ios":
-				out = filepath.Join(dir, "Cgopkg.framework")
+				out = filepath.Join(dir, "Cgopkg.xcframework")
 			}
 
 			tests := []struct {


### PR DESCRIPTION
This WIP PR provides a nominally working update to support `.xcframework` generation with go1.15, which has removed support for some 32 bit architectures. See: https://github.com/dpwiese/mobile/pull/1#issuecomment-761931422. In addition, unlike https://github.com/dpwiese/mobile/pull/1 this PR doesn't require manual thinning or combining of the generated `.framework`s for each of the various "architectures" - this is now done automatically.

**Todo**
- [ ] Fix tests
    ```
    bind_test.go:321: gomobile bind failed: exit status 1
    go: cannot determine module path for source directory
    Run 'go help mod init' for more information.
    ````
    and
    ```
    could not import golang.org/x/mobile/gl
    ```
    *Note: on current `master` branch `TestIOSBuild` fails*